### PR TITLE
MkdirAllNewAs,CopyDirectory: ensure dir perms

### DIFF
--- a/fileutils.go
+++ b/fileutils.go
@@ -125,6 +125,7 @@ func CopyDirectory(source string, dest string) error {
 		if err != nil {
 			return nil
 		}
+		destPath := filepath.Join(dest, relPath)
 
 		if info.IsDir() {
 			// Skip the source directory.
@@ -138,18 +139,20 @@ func CopyDirectory(source string, dest string) error {
 				uid := int(st.Uid)
 				gid := int(st.Gid)
 
-				if err := os.Mkdir(filepath.Join(dest, relPath), info.Mode()); err != nil {
+				if err := os.Mkdir(destPath, info.Mode()); err != nil {
 					return err
 				}
-
-				if err := os.Lchown(filepath.Join(dest, relPath), uid, gid); err != nil {
+				if err := os.Lchown(destPath, uid, gid); err != nil {
+					return err
+				}
+				if err := os.Chmod(destPath, info.Mode()); err != nil {
 					return err
 				}
 			}
 			return nil
 		}
 
-		return CopyFile(path, filepath.Join(dest, relPath))
+		return CopyFile(path, destPath)
 	})
 }
 

--- a/idtools.go
+++ b/idtools.go
@@ -49,6 +49,9 @@ func MkdirAllNewAs(path string, mode os.FileMode, ownerUID, ownerGID int) error 
 		if err := os.Chown(pathComponent, ownerUID, ownerGID); err != nil {
 			return err
 		}
+		if err := os.Chmod(pathComponent, mode); err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Because of umask, sometimes newly created files and directories can have permission bits different than expected. An easy solution would be to call os.Chmod after creation -- this is how CopyFile already works.

Now, let's do the same for directories.

PS The alternative to that would be to temporary set umask to 0, but it is extremely problematic in Go as it affects other threads (for all the gory details, see comments in https://github.com/opencontainers/runc/pull/3563).

For https://github.com/opencontainers/runc/issues/3991